### PR TITLE
Update Jackson to 2.9.10 (fixes #3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
     </repository>
   </repositories>
 
+  <properties>
+  	<version.jackson>2.9.10</version.jackson>
+  </properties>
+  
   <dependencies>
     <!--compile deps-->
     <dependency>
@@ -54,17 +58,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.8</version>
+      <version>${version.jackson}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.9.8</version>
+      <version>${version.jackson}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>${version.jackson}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
- Externalize version to property