### PR TITLE
Add missing 'Order' attribute in UpdateConfig

### DIFF
--- a/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
+++ b/src/main/java/com/spotify/docker/client/messages/swarm/UpdateConfig.java
@@ -47,11 +47,16 @@ public abstract class UpdateConfig {
   @JsonProperty("FailureAction")
   public abstract String failureAction();
 
+  @Nullable
+  @JsonProperty("Order")
+  public abstract String order();
+
   @JsonCreator
   public static UpdateConfig create(
       @JsonProperty("Parallelism") final Long parallelism,
       @JsonProperty("Delay") final Long delay,
-      @JsonProperty("FailureAction") final String failureAction) {
-    return new AutoValue_UpdateConfig(parallelism, delay, failureAction);
+      @JsonProperty("FailureAction") final String failureAction,
+      @JsonProperty("Order") final String order) {
+    return new AutoValue_UpdateConfig(parallelism, delay, failureAction, order);
   }
 }

--- a/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/com/spotify/docker/client/DefaultDockerClientTest.java
@@ -5085,7 +5085,7 @@ public class DefaultDockerClientTest {
         .name(serviceName)
         .taskTemplate(taskSpec)
         .mode(serviceMode)
-        .updateConfig(UpdateConfig.create(null, null, null))
+        .updateConfig(UpdateConfig.create(null, null, null, null))
         .networks(Collections.emptyList())
         .endpointSpec(EndpointSpec.builder()
             .addPort(PortConfig.builder().build())
@@ -5105,6 +5105,11 @@ public class DefaultDockerClientTest {
     assertThat(actualServiceSpec.endpointSpec().mode(),
         equalTo(EndpointSpec.Mode.RESOLUTION_MODE_VIP));
     assertThat(actualServiceSpec.updateConfig().failureAction(), equalTo("pause"));
+    // The update order attribute was added in the version 17.05.0-ce of docker and the version 1.29
+    // of the docker engine API
+    if (dockerApiVersionAtLeast("1.29")) {
+      assertThat(actualServiceSpec.updateConfig().order(), equalTo("stop-first"));
+    }
 
     final PortConfig.Builder portConfigBuilder = PortConfig.builder()
         .protocol(PROTOCOL_TCP);


### PR DESCRIPTION
Hello, can you please merge this change ? The original pull request was at https://github.com/spotify/docker-client/pull/1149

The purpose was to be able to do update without downtime (we can specify the update order to 'start-first' and the new instance will first start before shutting down the old instance, when combined with health check it's perfect)