### PR TITLE
Avoid reading response entity on exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ projects are affected in the following ways:
 * Shading support has been dropped as a side-effect of providing API consistency between
 different client builders.
 
+* `DockerRequestException` has stopped holding the response body at all cases. This 
+is because RESTeasy (compared to Jersey) closes the response when an exception is thrown, 
+hiding the actual error when trying to read it. The specification is still 
+[unclear](https://github.com/eclipse-ee4j/jaxrs-api/issues/736) about whether JAXRS 
+implementations must close the response or not.
+
 ### Changes
 
 * Rationalize DefaultDockerClient and Builder responsibilities (fixes #161, #91)

--- a/src/main/java/org/mandas/docker/client/DefaultDockerClient.java
+++ b/src/main/java/org/mandas/docker/client/DefaultDockerClient.java
@@ -2571,7 +2571,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
     if (response != null) {
       throw new DockerRequestException(method, resource.getUri(), response.getStatus(),
-    		  	response.readEntity(String.class), cause);
+    		  	null, cause);
     } else if (cause instanceof InterruptedIOException) {
       throw new DockerTimeoutException(method, resource.getUri(), ex);
     } else if (cause instanceof InterruptedException) {

--- a/src/test/java/org/mandas/docker/client/DefaultDockerClientTest.java
+++ b/src/test/java/org/mandas/docker/client/DefaultDockerClientTest.java
@@ -275,8 +275,6 @@ import org.mandas.docker.client.messages.swarm.UpdateConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -3861,15 +3859,7 @@ public class DefaultDockerClientTest {
     try {
       sut.resizeTty(id, 100, 80);
       fail("Should get an exception resizing TTY for non-running container");
-    } catch (DockerRequestException e) {
-      final ObjectMapper mapper = ObjectMapperProvider.objectMapper();
-      final Map<String, String> jsonMessage =
-          mapper.readValue(e.getResponseBody(), new TypeReference<Map<String, String>>() {
-          });
-      assertThat(jsonMessage, hasKey("message"));
-      assertEquals(String.format("Container %s is not running", id),
-                   jsonMessage.get("message"));
-    }
+    } catch (DockerRequestException e) {}
 
     sut.startContainer(id);
 


### PR DESCRIPTION
- RESTeasy closes the response on exception