### PR TITLE
Fix ImageInfo message for Docker 25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - 'v*'
 
 env:
-  DOCKER_VERSION: 24.0.7
+  DOCKER_VERSION: 25.0.1
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
 
 env:
-  DOCKER_VERSION: 24.0.7
+  DOCKER_VERSION: 25.0.1
 
 jobs:
   build:

--- a/src/main/java/org/mandas/docker/client/messages/ImageInfo.java
+++ b/src/main/java/org/mandas/docker/client/messages/ImageInfo.java
@@ -24,6 +24,7 @@ package org.mandas.docker.client.messages;
 import java.util.Date;
 
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Default;
 import org.mandas.docker.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -69,8 +70,12 @@ public interface ImageInfo {
   @JsonProperty("Size")
   Long size();
 
+  @Deprecated
+  @Default
   @JsonProperty("VirtualSize")
-  Long virtualSize();
+  default Long virtualSize() {
+    return size();
+  }
 
   @Nullable
   @JsonProperty("RootFS")


### PR DESCRIPTION
Hi, first of all, many thanks for maintaining this fork. It is a great help for us!

With the release of Docker 25.0, the `ImageInfo` message no longer contains the `VirtualSize` field, see https://docs.docker.com/engine/api/version-history/ .

This PR makes the field nullable,so that it still works with older versions of docker.