### PR TITLE
Add @nullable to optional fields in DeviceRequest

### DIFF
--- a/src/main/java/org/mandas/docker/client/messages/HostConfig.java
+++ b/src/main/java/org/mandas/docker/client/messages/HostConfig.java
@@ -657,18 +657,22 @@ public interface HostConfig {
   @Immutable
   public interface DeviceRequest {
 	  
+	  @Nullable
 	  @JsonProperty("Driver")
 	  String driver();
 	  
+	  @Nullable
 	  @JsonProperty("Count")
 	  Integer count();
 	  
+	  @Nullable
 	  @JsonProperty("DeviceIDs")
 	  List<String> deviceIds();
 	  
 	  @JsonProperty("Capabilities")
 	  List<List<String>> capabilities();
 	  
+	  @Nullable
 	  @JsonProperty("Options")
 	  Map<String, String> options();
 	  


### PR DESCRIPTION
Hi

I'm trying to use this client to create a container with some GPU devices. According to the docs and my tests some fields are optional, but these are not marked as `@Nullable` in the code and therefore cause an issue.

This PR adds the `@Nullable` to the optional fields. I'm not sure whether it makes sense to add `@Nullable` to the List and Maps?

See for example the docker compose docs: https://docs.docker.com/compose/gpu-support/#enabling-gpu-access-to-service-containers

Thanks!