### PR TITLE
Make userNs configurable

### DIFF
--- a/src/main/java/org/mandas/docker/client/messages/HostConfig.java
+++ b/src/main/java/org/mandas/docker/client/messages/HostConfig.java
@@ -209,6 +209,10 @@ public interface HostConfig {
   String pidMode();
 
   @Nullable
+  @JsonProperty("UsernsMode")
+  String usernsMode();
+
+  @Nullable
   @JsonProperty("ShmSize")
   Long shmSize();
 
@@ -458,6 +462,8 @@ public interface HostConfig {
       pidMode("host");
       return this;
     }
+
+    Builder usernsMode(String usernsMode);
 
     Builder shmSize(Long shmSize);
 


### PR DESCRIPTION
Ran into this when trying to run [k3s](https://k3s.io/) in a rootless docker that has [userns-remap](https://docs.docker.com/engine/security/userns-remap/) configured, which means `privileged(true)` does not work. The solution is to then override `UsernsMode` to `host` when running the container.