### PR TITLE
Use default Docker Desktop unix socket on Mac

### DIFF
--- a/src/main/java/org/mandas/docker/client/DockerHost.java
+++ b/src/main/java/org/mandas/docker/client/DockerHost.java
@@ -22,6 +22,8 @@
 package org.mandas.docker.client;
 
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
@@ -38,6 +40,8 @@ public class DockerHost {
     String getProperty(String key);
 
     String getenv(String name);
+
+    boolean fileExists(String path);
   }
 
   private static final SystemDelegate defaultSystemDelegate = new SystemDelegate() {
@@ -49,6 +53,12 @@ public class DockerHost {
     @Override
     public String getenv(final String name) {
       return System.getenv(name);
+    }
+
+    @Override
+    public boolean fileExists(String path) {
+      final Path p = Path.of(path);
+      return Files.exists(p);
     }
   };
   private static SystemDelegate systemDelegate = defaultSystemDelegate;
@@ -180,8 +190,14 @@ public class DockerHost {
   static String defaultDockerEndpoint() {
     final String osName = systemDelegate.getProperty("os.name");
     final String os = osName.toLowerCase(Locale.ENGLISH);
-    if (os.equals("linux") || os.contains("mac")) {
+    if (os.equals("linux")) {
       return DEFAULT_UNIX_ENDPOINT;
+    } else if (os.contains("mac")) {
+      if (systemDelegate.fileExists(DEFAULT_UNIX_ENDPOINT)) {
+        return DEFAULT_UNIX_ENDPOINT;
+      }
+      final String userHome = systemDelegate.getProperty("user.home");
+      return "unix://" + userHome + "/.docker/run/docker.sock";
     }
     return DEFAULT_ADDRESS + ":" + defaultPort();
   }

--- a/src/test/java/org/mandas/docker/client/DockerHostTest.java
+++ b/src/test/java/org/mandas/docker/client/DockerHostTest.java
@@ -51,11 +51,22 @@ public class DockerHostTest {
   @Test
   public void testDefaultDockerEndpoint() throws Exception {
     when(systemDelegate.getProperty("os.name")).thenReturn("linux", "mac", "other");
+    when(systemDelegate.fileExists("unix:///var/run/docker.sock")).thenReturn(true);
     DockerHost.setSystemDelegate(systemDelegate);
 
     assertThat(DockerHost.defaultDockerEndpoint(), equalTo("unix:///var/run/docker.sock"));
     assertThat(DockerHost.defaultDockerEndpoint(), equalTo("unix:///var/run/docker.sock"));
     assertThat(DockerHost.defaultDockerEndpoint(), equalTo("localhost:2375"));
+  }
+
+  @Test
+  public void testDefaultDockerEndpointForDockerDesktopOnMac() throws Exception {
+    when(systemDelegate.getProperty("os.name")).thenReturn("mac");
+    when(systemDelegate.getProperty("user.home")).thenReturn("/Users/test-user");
+    when(systemDelegate.fileExists("unix:///var/run/docker.sock")).thenReturn(false);
+    DockerHost.setSystemDelegate(systemDelegate);
+
+    assertThat(DockerHost.defaultDockerEndpoint(), equalTo("unix:///Users/test-user/.docker/run/docker.sock"));
   }
 
   @Test


### PR DESCRIPTION
Default `unix:///var/run/docker.sock` is not always available on Mac OS
For Docker Desktop you have to set user-specific socket path via
```bash
export DOCKER_HOST="unix://$HOME/.docker/run/docker.sock"
```

This PR tries to check whether default socket is available and if not, returns the user-specific ones.
It simplifies client usage for default configurations on different systems.